### PR TITLE
replace deprecated arguments docker_image_tag and docker_image

### DIFF
--- a/Terraform_Script_Create_WP/main.tf
+++ b/Terraform_Script_Create_WP/main.tf
@@ -80,7 +80,6 @@ resource "azurerm_service_plan" "app_service_hosting_plan" {
 # Web app
 resource "azurerm_linux_web_app" "wordpress_web_app" {
   app_settings = {
-    DOCKER_REGISTRY_SERVER_URL          = var.app_service_docker_registry_url
     WEBSITES_ENABLE_APP_SERVICE_STORAGE = "true"
     DATABASE_HOST                       = "${var.mysql_server_name}.mysql.database.azure.com"
     DATABASE_USERNAME                   = var.mysql_server_username
@@ -114,8 +113,8 @@ resource "azurerm_linux_web_app" "wordpress_web_app" {
     always_on              = var.app_service_alwayson
     vnet_route_all_enabled = true
     application_stack {
-      docker_image     = var.wordpress_container_linux_fx_version
-      docker_image_tag = "latest"
+      docker_image_name   = "${var.wordpress_container_linux_fx_version}:latest"
+      docker_registry_url = var.app_service_docker_registry_url
     }
   }
   depends_on = [

--- a/Terraform_Script_Create_WP/main.tf
+++ b/Terraform_Script_Create_WP/main.tf
@@ -113,7 +113,7 @@ resource "azurerm_linux_web_app" "wordpress_web_app" {
     always_on              = var.app_service_alwayson
     vnet_route_all_enabled = true
     application_stack {
-      docker_image_name   = "${var.wordpress_container_linux_fx_version}:latest"
+      docker_image_name   = "${var.wordpress_container_linux_fx_version}:8.2"
       docker_registry_url = var.app_service_docker_registry_url
     }
   }

--- a/Terraform_Script_Create_WP/variables.tf
+++ b/Terraform_Script_Create_WP/variables.tf
@@ -214,7 +214,7 @@ variable "wordpress_locale_code" {
 }
 variable "wordpress_container_linux_fx_version" {
   description = "WP Container Image version"
-  default     = "mcr.microsoft.com/appsvc/wordpress-alpine-php"
+  default     = "appsvc/wordpress-alpine-php"
 }
 
 


### PR DESCRIPTION
replaced the deprecated arguments. See here:
https://github.com/hashicorp/terraform-provider-azurerm/pull/22003
and here:
https://github.com/hashicorp/terraform-provider-azurerm/blob/main/CHANGELOG.md