### PR TITLE
replace apk with apt-get

### DIFF
--- a/WordPress/wordpress_adding_php_extensions.md
+++ b/WordPress/wordpress_adding_php_extensions.md
@@ -17,8 +17,8 @@ Customers who need to install PHP extensions that are not available on the WordP
    >**Note:** Depending on the version of the PHP, the name of the package needs to be updated accordingly. Additionally, you can use the [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages) dashboard to search for your required PHP extensions. You can make use of wildcards (* and ?) in the search.
 
    ```bash
-    apk update
-    apk add php8-soap
+    apt-get update
+    apt-get install php8-soap
    ```
 
 1. For PHP 8, the extensions will be installed under **/usr/lib/php8/modules/**. If you are not able to find it, you can make use of **find** command to locate the extension file.

--- a/WordPress/wordpress_intl_extension.md
+++ b/WordPress/wordpress_intl_extension.md
@@ -4,7 +4,8 @@
 
 1. Run the below code only once from the SSH console of your App Service.
     ```
-    apk add icu-dev && \
+    apt-get update && \
+    apt-get install -y libicu-dev && \
     docker-php-ext-configure intl && \
     docker-php-ext-install intl && \
     docker-php-ext-enable intl


### PR DESCRIPTION
The original commands were for Alpine Linux. The default App Service now uses Debian.