### PR TITLE
Added support for wordpress images based out of PHP 8.4

### DIFF
--- a/ARM_Template_Create_WP/azuredeploy.parameters.json
+++ b/ARM_Template_Create_WP/azuredeploy.parameters.json
@@ -48,7 +48,7 @@
             "value": true
         },
         "linuxFxVersion": {
-            "value": "DOCKER|mcr.microsoft.com/appsvc/wordpress-alpine-php:8.3"
+            "value": "DOCKER|mcr.microsoft.com/appsvc/wordpress-debian-php:8.4"
         },
         "dockerRegistryUrl": {
             "value": "https://mcr.microsoft.com"

--- a/Bicep_Script_Create_WP/main.bicep
+++ b/Bicep_Script_Create_WP/main.bicep
@@ -47,7 +47,7 @@ param numberOfWorkers int = 1
 param kind string = 'linux'
 param reserved bool = true
 param alwaysOn bool = true
-param linuxFxVersion string = 'DOCKER|mcr.microsoft.com/appsvc/wordpress-alpine-php:latest'
+param linuxFxVersion string = 'DOCKER|mcr.microsoft.com/appsvc/wordpress-debian-php:8.4'
 param dockerRegistryUrl string = 'https://mcr.microsoft.com'
 param storageSizeGB int = 128
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ While there are multiple WordPress options on Azure, we recommend starting with 
 
    | Image Name | Image Stack Version | OS | PHP Version  | Comments |
    |------------|------------|------------|---------------|----------|
-   | mcr.microsoft.com/appsvc/wordpress-debian-php | 8.3 | Debian bookworm | 8.3 |✅ Supported and recommended |
+   | mcr.microsoft.com/appsvc/wordpress-debian-php | 8.4 | Debian bookworm | 8.4 |✅ Supported and recommended |
+   | mcr.microsoft.com/appsvc/wordpress-debian-php | 8.3 | Debian bookworm | 8.3 |✅ Supported |
    | mcr.microsoft.com/appsvc/wordpress-debian-php | 8.2 | Debian bullseye | 8.2 |✅ Supported |
    | mcr.microsoft.com/appsvc/wordpress-alpine-php | 8.3 | Alpine Linux 3 | 8.3 |⚠️ Supported (End of support Dec'24) but recommended to migrate to `Debian` based image |
    | mcr.microsoft.com/appsvc/wordpress-alpine-php | 8.2 | Alpine Linux 3 | 8.2 |⚠️ Supported (End of support Dec'24) but recommended to migrate to `Debian` based image |

--- a/Terraform_Script_Create_WP/main.tf
+++ b/Terraform_Script_Create_WP/main.tf
@@ -116,7 +116,7 @@ resource "azurerm_linux_web_app" "wordpress_web_app" {
 
     application_stack {
       docker_image = "${var.app_service_docker_registry_url}/${var.wordpress_container_linux_fx_version}"
-      docker_image_tag = "8.2"
+      docker_image_tag = "8.4"
     }
   }
 

--- a/Terraform_Script_Create_WP/variables.tf
+++ b/Terraform_Script_Create_WP/variables.tf
@@ -214,7 +214,7 @@ variable "wordpress_locale_code" {
 }
 variable "wordpress_container_linux_fx_version" {
   description = "WP Container Image version"
-  default     = "appsvc/wordpress-alpine-php"
+  default     = "appsvc/wordpress-debian-php"
 }
 
 

--- a/WordPress/wordpress_azure_ci_cd.md
+++ b/WordPress/wordpress_azure_ci_cd.md
@@ -105,14 +105,14 @@ wp-config.php
     ```
     az login
     az account set --subscription SUBSCRIPTION_ID
-    az webapp config set --name WEBAPP_NAME --resource-group RESOURCE_GROUP_NAME --linux-fx-version "DOCKER|mcr.microsoft.com/appsvc/wordpress-alpine-php:8.3"
+    az webapp config set --name WEBAPP_NAME --resource-group RESOURCE_GROUP_NAME --linux-fx-version "DOCKER|mcr.microsoft.com/appsvc/wordpress-debian-php:8.4"
     ```
 - You can also update the image details of the App Service using the [REST interface](https://learn.microsoft.com/en-us/rest/api/appservice/web-apps/create-or-update-configuration?view=rest-appservice-2022-03-01#code-try-0) and use the following json as body. You also need to specify the app name, resource group name and subscription in the parameters section.
 
     ```
     {
         "properties": {
-            "linuxFxVersion": "DOCKER|mcr.microsoft.com/appsvc/wordpress-alpine-php:8.3"
+            "linuxFxVersion": "DOCKER|mcr.microsoft.com/appsvc/wordpress-debian-php:8.4"
         }
     }
     ```


### PR DESCRIPTION
PHP 8.4 based sites is the latest and recommended option to create wordpress sites on Linux App Service.

This PR change the defaults in following areas:
- ReadMe.Md
- ARM template
- Bicep template
- Terraform template