### PR TITLE
Add flexible VNet and subnet deployment support

### DIFF
--- a/ARM_Template_Create_WP/azuredeploy.json
+++ b/ARM_Template_Create_WP/azuredeploy.json
@@ -210,34 +210,6 @@
             "metadata": {
                 "description": "Set to false to skip subnet creation (useful when subnets already exist)"
             }
-        },
-        "vnetAddressPrefix": {
-            "type": "string",
-            "defaultValue": "10.0.0.0/16",
-            "metadata": {
-                "description": "Address space for the VNet (e.g., 10.0.0.0/16)"
-            }
-        },
-        "subnetAddressForApp": {
-            "type": "string",
-            "defaultValue": "10.0.0.0/24",
-            "metadata": {
-                "description": "Address prefix for the App Service subnet (e.g., 10.0.0.0/24)"
-            }
-        },
-        "subnetAddressForDb": {
-            "type": "string",
-            "defaultValue": "10.0.1.0/24",
-            "metadata": {
-                "description": "Address prefix for the Database subnet (e.g., 10.0.1.0/24)"
-            }
-        },
-        "useExistingPrivateDnsZone": {
-            "type": "bool",
-            "defaultValue": false,
-            "metadata": {
-                "description": "Set to true to use an existing Private DNS Zone instead of creating a new one"
-            }
         }
     },
     "resources": [
@@ -427,7 +399,7 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', parameters('privateDnsZoneNameForDb'), format('{0}-vnetlink', parameters('privateDnsZoneNameForDb')))]",
                 "[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('managedIdentityName'))]",
-                "[if(parameters('createSubnets'), resourceId('Microsoft.Resources/deployments', 'subnet_Resources'), if(parameters('useExistingVnet'), resourceId('Microsoft.Resources/deployments', 'update_existing_subnets'), resourceId('Microsoft.Network/virtualNetworks/', parameters('vnetName'))))]"
+                "[if(parameters('createSubnets'), resourceId('Microsoft.Resources/deployments', 'subnet_Resources'), if(parameters('useExistingVnet'), resourceId('Microsoft.Resources/deployments', 'add_delegations'), resourceId('Microsoft.Network/virtualNetworks/', parameters('vnetName'))))]"
             ],
             "identity": {
                 "type": "UserAssigned",
@@ -555,7 +527,7 @@
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
-                        "[parameters('vnetAddressPrefix')]"
+                        "[variables('vnetAddress')]"
                     ]
                 },
                 "subnets": []
@@ -569,8 +541,6 @@
             "condition": "[parameters('createSubnets')]",
             "dependsOn": [
             ],
-            "resourceGroup": "[parameters('serverFarmResourceGroup')]",
-            "subscriptionId": "[subscription().subscriptionId]",
             "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -584,7 +554,7 @@
                             "apiVersion": "2021-03-01",
                             "name": "[format('{0}/{1}', parameters('vnetName'), parameters('subnetForApp'))]",
                             "properties": {
-                                "addressPrefix": "[parameters('subnetAddressForApp')]",
+                                "addressPrefix": "[variables('subnetAddressForApp')]",
                                 "delegations": [
                                     {
                                         "name": "dlg-appService",
@@ -600,7 +570,7 @@
                             "apiVersion": "2021-03-01",
                             "name": "[format('{0}/{1}',parameters('vnetName'), parameters('subnetForDb'))]",
                             "properties": {
-                                "addressPrefix": "[parameters('subnetAddressForDb')]",
+                                "addressPrefix": "[variables('subnetAddressForDb')]",
                                 "delegations": [
                                     {
                                         "name": "dlg-appService",
@@ -620,13 +590,11 @@
         },
         {
             "type": "Microsoft.Resources/deployments",
-            "name": "update_existing_subnets",
+            "name": "add_delegations",
             "apiVersion": "[variables('resourceDeploymentApiVersion')]",
             "condition": "[and(parameters('useExistingVnet'), not(parameters('createSubnets')))]",
             "dependsOn": [
             ],
-            "resourceGroup": "[parameters('serverFarmResourceGroup')]",
-            "subscriptionId": "[subscription().subscriptionId]",
             "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -640,7 +608,7 @@
                             "apiVersion": "2021-03-01",
                             "name": "[format('{0}/{1}', parameters('vnetName'), parameters('subnetForApp'))]",
                             "properties": {
-                                "addressPrefix": "[parameters('subnetAddressForApp')]",
+                                "addressPrefix": "[reference(resourceId(parameters('serverFarmResourceGroup'), 'Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetForApp')), '2021-03-01').addressPrefix]",
                                 "delegations": [
                                     {
                                         "name": "dlg-appService",
@@ -656,7 +624,7 @@
                             "apiVersion": "2021-03-01",
                             "name": "[format('{0}/{1}',parameters('vnetName'), parameters('subnetForDb'))]",
                             "properties": {
-                                "addressPrefix": "[parameters('subnetAddressForDb')]",
+                                "addressPrefix": "[reference(resourceId(parameters('serverFarmResourceGroup'), 'Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetForDb')), '2021-03-01').addressPrefix]",
                                 "delegations": [
                                     {
                                         "name": "dlg-mysql",
@@ -701,7 +669,7 @@
             ],
             "dependsOn": [
                 "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
-                "[if(parameters('createSubnets'), resourceId('Microsoft.Resources/deployments', 'subnet_Resources'), if(parameters('useExistingVnet'), resourceId('Microsoft.Resources/deployments', 'update_existing_subnets'), resourceId('Microsoft.Network/virtualNetworks/', parameters('vnetName'))))]"
+                "[if(parameters('createSubnets'), resourceId('Microsoft.Resources/deployments', 'subnet_Resources'), if(parameters('useExistingVnet'), resourceId('Microsoft.Resources/deployments', 'add_delegations'), resourceId('Microsoft.Network/virtualNetworks/', parameters('vnetName'))))]"
             ]
         },
         {
@@ -1163,6 +1131,9 @@
         "databaseVersion": "8.0.21",
         "vnetDeploymentApiVersion": "2020-07-01",
         "privateDnsApiVersion": "2018-09-01",
+        "vnetAddress": "10.0.0.0/23",
+        "subnetAddressForApp": "10.0.0.0/24",
+        "subnetAddressForDb": "10.0.1.0/24",
         "blobApiVersion": "2021-08-01",
         "storageAccountId": "[resourceId(parameters('storageAccountResourceGroup'),'Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
         "emailApiVersion": "2023-03-31",

--- a/ARM_Template_Create_WP/azuredeploy.json
+++ b/ARM_Template_Create_WP/azuredeploy.json
@@ -119,18 +119,6 @@
         "wpLocaleCode": {
             "type": "string"
         },
-        "cdnProfileName": {
-            "type": "string"
-        },
-        "cdnEndpointName": {
-            "type": "string"
-        },
-        "cdnType": {
-            "type": "string"
-        },
-        "stagingCdnEndpointName": {
-            "type": "string"
-        },
         "storageAccountName": {
             "type": "string"
         },
@@ -208,6 +196,48 @@
         },
         "managedIdentityName": {
             "type": "string"
+        },
+        "useExistingVnet": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Set to true to use an existing VNet instead of creating a new one"
+            }
+        },
+        "createSubnets": {
+            "type": "bool",
+            "defaultValue": true,
+            "metadata": {
+                "description": "Set to false to skip subnet creation (useful when subnets already exist)"
+            }
+        },
+        "vnetAddressPrefix": {
+            "type": "string",
+            "defaultValue": "10.0.0.0/16",
+            "metadata": {
+                "description": "Address space for the VNet (e.g., 10.0.0.0/16)"
+            }
+        },
+        "subnetAddressForApp": {
+            "type": "string",
+            "defaultValue": "10.0.0.0/24",
+            "metadata": {
+                "description": "Address prefix for the App Service subnet (e.g., 10.0.0.0/24)"
+            }
+        },
+        "subnetAddressForDb": {
+            "type": "string",
+            "defaultValue": "10.0.1.0/24",
+            "metadata": {
+                "description": "Address prefix for the Database subnet (e.g., 10.0.1.0/24)"
+            }
+        },
+        "useExistingPrivateDnsZone": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Set to true to use an existing Private DNS Zone instead of creating a new one"
+            }
         }
     },
     "resources": [
@@ -274,14 +304,6 @@
                         {
                             "name": "DATABASE_USERNAME",
                             "value": "[parameters('managedIdentityName')]"
-                        },
-                        {
-                            "name": "CDN_ENABLED",
-                            "value": "true"
-                        },
-                        {
-                            "name": "CDN_ENDPOINT",
-                            "value": "[concat(parameters('cdnEndPointName'),'.azureedge.net')]"
                         },
                         {
                             "name": "BLOB_STORAGE_ENABLED",
@@ -405,7 +427,7 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', parameters('privateDnsZoneNameForDb'), format('{0}-vnetlink', parameters('privateDnsZoneNameForDb')))]",
                 "[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('managedIdentityName'))]",
-                "[resourceId('Microsoft.Resources/deployments', 'subnet_Resources')]"
+                "[if(parameters('createSubnets'), resourceId('Microsoft.Resources/deployments', 'subnet_Resources'), if(parameters('useExistingVnet'), resourceId('Microsoft.Resources/deployments', 'update_existing_subnets'), resourceId('Microsoft.Network/virtualNetworks/', parameters('vnetName'))))]"
             ],
             "identity": {
                 "type": "UserAssigned",
@@ -524,6 +546,7 @@
         {
             "type": "Microsoft.Network/virtualNetworks",
             "apiVersion": "[variables('vnetDeploymentApiVersion')]",
+            "condition": "[not(parameters('useExistingVnet'))]",
             "location": "[parameters('location')]",
             "name": "[parameters('vnetName')]",
             "tags": {
@@ -532,7 +555,7 @@
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
-                        "[variables('vnetAddress')]"
+                        "[parameters('vnetAddressPrefix')]"
                     ]
                 },
                 "subnets": []
@@ -543,11 +566,11 @@
             "type": "Microsoft.Resources/deployments",
             "name": "subnet_Resources",
             "apiVersion": "[variables('resourceDeploymentApiVersion')]",
+            "condition": "[parameters('createSubnets')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]"
             ],
-            "resourceGroup": "rajneesh-experiments",
-            "subscriptionId": "9801ce74-29e4-4846-9d02-5010413d1042",
+            "resourceGroup": "[parameters('serverFarmResourceGroup')]",
+            "subscriptionId": "[subscription().subscriptionId]",
             "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -561,7 +584,7 @@
                             "apiVersion": "2021-03-01",
                             "name": "[format('{0}/{1}', parameters('vnetName'), parameters('subnetForApp'))]",
                             "properties": {
-                                "addressPrefix": "10.0.0.0/25",
+                                "addressPrefix": "[parameters('subnetAddressForApp')]",
                                 "delegations": [
                                     {
                                         "name": "dlg-appService",
@@ -577,10 +600,66 @@
                             "apiVersion": "2021-03-01",
                             "name": "[format('{0}/{1}',parameters('vnetName'), parameters('subnetForDb'))]",
                             "properties": {
-                                "addressPrefix": "10.0.0.128/25",
+                                "addressPrefix": "[parameters('subnetAddressForDb')]",
                                 "delegations": [
                                     {
                                         "name": "dlg-appService",
+                                        "properties": {
+                                            "serviceName": "Microsoft.DBforMySQL/flexibleServers"
+                                        }
+                                    }
+                                ]
+                            },
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetForApp'))]"
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "name": "update_existing_subnets",
+            "apiVersion": "[variables('resourceDeploymentApiVersion')]",
+            "condition": "[and(parameters('useExistingVnet'), not(parameters('createSubnets')))]",
+            "dependsOn": [
+            ],
+            "resourceGroup": "[parameters('serverFarmResourceGroup')]",
+            "subscriptionId": "[subscription().subscriptionId]",
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.1",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "type": "Microsoft.Network/virtualNetworks/subnets",
+                            "apiVersion": "2021-03-01",
+                            "name": "[format('{0}/{1}', parameters('vnetName'), parameters('subnetForApp'))]",
+                            "properties": {
+                                "addressPrefix": "[parameters('subnetAddressForApp')]",
+                                "delegations": [
+                                    {
+                                        "name": "dlg-appService",
+                                        "properties": {
+                                            "serviceName": "Microsoft.Web/serverFarms"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "Microsoft.Network/virtualNetworks/subnets",
+                            "apiVersion": "2021-03-01",
+                            "name": "[format('{0}/{1}',parameters('vnetName'), parameters('subnetForDb'))]",
+                            "properties": {
+                                "addressPrefix": "[parameters('subnetAddressForDb')]",
+                                "delegations": [
+                                    {
+                                        "name": "dlg-mysql",
                                         "properties": {
                                             "serviceName": "Microsoft.DBforMySQL/flexibleServers"
                                         }
@@ -622,7 +701,7 @@
             ],
             "dependsOn": [
                 "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
-                "[resourceId('Microsoft.Resources/deployments', 'subnet_Resources')]"
+                "[if(parameters('createSubnets'), resourceId('Microsoft.Resources/deployments', 'subnet_Resources'), if(parameters('useExistingVnet'), resourceId('Microsoft.Resources/deployments', 'update_existing_subnets'), resourceId('Microsoft.Network/virtualNetworks/', parameters('vnetName'))))]"
             ]
         },
         {
@@ -715,14 +794,6 @@
                         {
                             "name": "DATABASE_USERNAME",
                             "value": "[parameters('managedIdentityName')]"
-                        },
-                        {
-                            "name": "CDN_ENABLED",
-                            "value": "true"
-                        },
-                        {
-                            "name": "CDN_ENDPOINT",
-                            "value": "[concat(parameters('stagingCdnEndpointName'),'.azureedge.net')]"
                         },
                         {
                             "name": "BLOB_STORAGE_ENABLED",
@@ -911,14 +982,6 @@
                                         "value": "[parameters('managedIdentityName')]"
                                     },
                                     {
-                                        "name": "CDN_ENABLED",
-                                        "value": "true"
-                                    },
-                                    {
-                                        "name": "CDN_ENDPOINT",
-                                        "value": "[concat(parameters('cdnEndPointName'),'.azureedge.net')]"
-                                    },
-                                    {
                                         "name": "BLOB_STORAGE_ENABLED",
                                         "value": "true"
                                     },
@@ -947,373 +1010,6 @@
                                         "value": "true"
                                     }
                                 ]
-                            }
-                        }
-                    ]
-                }
-            }
-        },
-        {
-            "apiVersion": "[variables('cdnApiVersion')]",
-            "type": "Microsoft.Cdn/profiles",
-            "name": "[parameters('cdnProfileName')]",
-            "location": "Global",
-            "sku": {
-                "name": "[parameters('cdnType')]"
-            },
-            "tags": {
-                "AppProfile": "Wordpress"
-            },
-            "properties": {},
-            "dependsOn": [
-                "[resourceId('Microsoft.DBforMySQL/flexibleServers', parameters('serverName'))]"
-            ]
-        },
-        {
-            "apiVersion": "[variables('cdnApiVersion')]",
-            "type": "Microsoft.Cdn/profiles/endpoints",
-            "name": "[concat(parameters('cdnProfileName'),'/',parameters('cdnEndPointName'))]",
-            "location": "Global",
-            "tags": {
-                "AppProfile": "Wordpress"
-            },
-            "properties": {
-                "isHttpAllowed": true,
-                "isHttpsAllowed": true,
-                "isCompressionEnabled": true,
-                "contentTypesToCompress": [
-                    "application/eot",
-                    "application/font",
-                    "application/font-sfnt",
-                    "application/javascript",
-                    "application/json",
-                    "application/opentype",
-                    "application/otf",
-                    "application/pkcs7-mime",
-                    "application/truetype",
-                    "application/ttf",
-                    "application/vnd.ms-fontobject",
-                    "application/xhtml+xml",
-                    "application/xml",
-                    "application/xml+rss",
-                    "application/x-font-opentype",
-                    "application/x-font-truetype",
-                    "application/x-font-ttf",
-                    "application/x-httpd-cgi",
-                    "application/x-javascript",
-                    "application/x-mpegurl",
-                    "application/x-opentype",
-                    "application/x-otf",
-                    "application/x-perl",
-                    "application/x-ttf",
-                    "font/eot",
-                    "font/ttf",
-                    "font/otf",
-                    "font/opentype",
-                    "image/svg+xml",
-                    "text/css",
-                    "text/csv",
-                    "text/html",
-                    "text/javascript",
-                    "text/js",
-                    "text/plain",
-                    "text/richtext",
-                    "text/tab-separated-values",
-                    "text/xml",
-                    "text/x-script",
-                    "text/x-component",
-                    "text/x-java-source"
-                ],
-                "origins": [
-                    {
-                        "name": "sample-wordpress-app-hvgxd6frewgccwas-australiacentral-01-azurewebsites-net",
-                        "properties": {
-                            "hostName": "sample-wordpress-app-hvgxd6frewgccwas.australiacentral-01.azurewebsites.net",
-                            "httpPort": 80,
-                            "httpsPort": 443,
-                            "originHostHeader": "sample-wordpress-app-hvgxd6frewgccwas.australiacentral-01.azurewebsites.net",
-                            "priority": 1,
-                            "weight": 1000,
-                            "enabled": true
-                        }
-                    },
-                    {
-                        "name": "sampleword0ab37a5082-blob-core-windows-net",
-                        "properties": {
-                            "hostName": "sampleword0ab37a5082.blob.core.windows.net",
-                            "httpPort": 80,
-                            "httpsPort": 443,
-                            "originHostHeader": "sampleword0ab37a5082.blob.core.windows.net",
-                            "priority": 1,
-                            "weight": 1000,
-                            "enabled": true
-                        }
-                    }
-                ],
-                "originGroups": [
-                    {
-                        "name": "blob-origin-group",
-                        "properties": {
-                            "origins": [
-                                {
-                                    "id": "[resourceId('Microsoft.Cdn/profiles/endpoints/origins', parameters('cdnProfileName'), parameters('cdnEndPointName'), 'sampleword0ab37a5082-blob-core-windows-net')]"
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "name": "app-origin-group",
-                        "properties": {
-                            "origins": [
-                                {
-                                    "id": "[resourceId('Microsoft.Cdn/profiles/endpoints/origins', parameters('cdnProfileName'), parameters('cdnEndPointName'), 'sample-wordpress-app-hvgxd6frewgccwas-australiacentral-01-azurewebsites-net')]"
-                                }
-                            ]
-                        }
-                    }
-                ],
-                "defaultOriginGroup": {
-                    "id": "[resourceId('Microsoft.Cdn/profiles/endpoints/originGroups', parameters('cdnProfileName'), parameters('cdnEndPointName'), 'blob-origin-group')]"
-                },
-                "geoFilters": [],
-                "deliveryPolicy": {
-                    "rules": [
-                        {
-                            "name": "originOverrideRule",
-                            "order": 1,
-                            "conditions": [
-                                {
-                                    "name": "UrlPath",
-                                    "parameters": {
-                                        "typeName": "DeliveryRuleUrlPathMatchConditionParameters",
-                                        "operator": "BeginsWith",
-                                        "negateCondition": true,
-                                        "matchValues": [
-                                            "[concat(parameters('blobContainerName'), '/wp-content/uploads/')]"
-                                        ],
-                                        "transforms": [
-                                            "Lowercase"
-                                        ]
-                                    }
-                                }
-                            ],
-                            "actions": [
-                                {
-                                    "name": "OriginGroupOverride",
-                                    "parameters": {
-                                        "typeName": "DeliveryRuleOriginGroupOverrideActionParameters",
-                                        "originGroup": {
-                                            "id": "[resourceId('Microsoft.Cdn/profiles/endpoints/originGroups', parameters('cdnProfileName'), parameters('cdnEndPointName'), 'app-origin-group')]"
-                                        }
-                                    }
-                                },
-                                {
-                                    "name": "UrlRewrite",
-                                    "parameters": {
-                                        "typeName": "DeliveryRuleUrlRewriteActionParameters",
-                                        "sourcePattern": "[concat('/', parameters('blobContainerName'), '/')]",
-                                        "destination": "/",
-                                        "preserveUnmatchedPath": true
-                                    }
-                                },
-                                {
-                                    "name": "ModifyResponseHeader",
-                                    "parameters": {
-                                        "typeName": "DeliveryRuleHeaderActionParameters",
-                                        "headerAction": "Overwrite",
-                                        "headerName": "Access-Control-Allow-Origin",
-                                        "value": "https://sample-wordpress-app-hvgxd6frewgccwas.australiacentral-01.azurewebsites.net"
-                                    }
-                                }
-                            ]
-                        }
-                    ]
-                }
-            },
-            "dependsOn": [
-                "[concat('Microsoft.Cdn/profiles/', parameters('cdnProfileName'))]",
-                "[resourceId('Microsoft.Web/Sites', parameters('name'))]",
-                "[resourceId('Microsoft.Resources/deployments', 'Storage_Resources')]"
-            ]
-        },
-        {
-            "type": "Microsoft.Resources/deployments",
-            "name": "staging_cdn_endpoint_deployment",
-            "apiVersion": "[variables('resourceDeploymentApiVersion')]",
-            "dependsOn": [
-                "[concat('Microsoft.Cdn/profiles/', parameters('cdnProfileName'))]",
-                "[resourceId('Microsoft.Web/Sites', parameters('name'))]",
-                "[resourceId('Microsoft.Resources/deployments', 'Storage_Resources')]",
-                "[resourceId('Microsoft.Web/sites/slots', parameters('name'), 'staging')]"
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.1",
-                    "parameters": {},
-                    "variables": {},
-                    "resources": [
-                        {
-                            "apiVersion": "[variables('cdnApiVersion')]",
-                            "type": "Microsoft.Cdn/profiles/endpoints",
-                            "name": "[concat(parameters('cdnProfileName'),'/',parameters('stagingCdnEndpointName'))]",
-                            "location": "Global",
-                            "tags": {
-                                "AppProfile": "Wordpress"
-                            },
-                            "properties": {
-                                "isHttpAllowed": true,
-                                "isHttpsAllowed": true,
-                                "isCompressionEnabled": true,
-                                "contentTypesToCompress": [
-                                    "application/eot",
-                                    "application/font",
-                                    "application/font-sfnt",
-                                    "application/javascript",
-                                    "application/json",
-                                    "application/opentype",
-                                    "application/otf",
-                                    "application/pkcs7-mime",
-                                    "application/truetype",
-                                    "application/ttf",
-                                    "application/vnd.ms-fontobject",
-                                    "application/xhtml+xml",
-                                    "application/xml",
-                                    "application/xml+rss",
-                                    "application/x-font-opentype",
-                                    "application/x-font-truetype",
-                                    "application/x-font-ttf",
-                                    "application/x-httpd-cgi",
-                                    "application/x-javascript",
-                                    "application/x-mpegurl",
-                                    "application/x-opentype",
-                                    "application/x-otf",
-                                    "application/x-perl",
-                                    "application/x-ttf",
-                                    "font/eot",
-                                    "font/ttf",
-                                    "font/otf",
-                                    "font/opentype",
-                                    "image/svg+xml",
-                                    "text/css",
-                                    "text/csv",
-                                    "text/html",
-                                    "text/javascript",
-                                    "text/js",
-                                    "text/plain",
-                                    "text/richtext",
-                                    "text/tab-separated-values",
-                                    "text/xml",
-                                    "text/x-script",
-                                    "text/x-component",
-                                    "text/x-java-source"
-                                ],
-                                "origins": [
-                                    {
-                                        "name": "sample-wordpress-app-staging-g8gbgbgwfvc2fkad-australiacentral-01-azurewebsites-net",
-                                        "properties": {
-                                            "hostName": "sample-wordpress-app-staging-g8gbgbgwfvc2fkad.australiacentral-01.azurewebsites.net",
-                                            "httpPort": 80,
-                                            "httpsPort": 443,
-                                            "originHostHeader": "sample-wordpress-app-staging-g8gbgbgwfvc2fkad.australiacentral-01.azurewebsites.net",
-                                            "priority": 1,
-                                            "weight": 1000,
-                                            "enabled": true
-                                        }
-                                    },
-                                    {
-                                        "name": "sampleword0ab37a5082-blob-core-windows-net",
-                                        "properties": {
-                                            "hostName": "sampleword0ab37a5082.blob.core.windows.net",
-                                            "httpPort": 80,
-                                            "httpsPort": 443,
-                                            "originHostHeader": "sampleword0ab37a5082.blob.core.windows.net",
-                                            "priority": 1,
-                                            "weight": 1000,
-                                            "enabled": true
-                                        }
-                                    }
-                                ],
-                                "originGroups": [
-                                    {
-                                        "name": "blob-origin-group",
-                                        "properties": {
-                                            "origins": [
-                                                {
-                                                    "id": "[resourceId('Microsoft.Cdn/profiles/endpoints/origins', parameters('cdnProfileName'), parameters('stagingCdnEndpointName'), 'sampleword0ab37a5082-blob-core-windows-net')]"
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "name": "app-origin-group",
-                                        "properties": {
-                                            "origins": [
-                                                {
-                                                    "id": "[resourceId('Microsoft.Cdn/profiles/endpoints/origins', parameters('cdnProfileName'), parameters('stagingCdnEndpointName'), 'sample-wordpress-app-staging-g8gbgbgwfvc2fkad-australiacentral-01-azurewebsites-net')]"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ],
-                                "defaultOriginGroup": {
-                                    "id": "[resourceId('Microsoft.Cdn/profiles/endpoints/originGroups', parameters('cdnProfileName'), parameters('stagingCdnEndpointName'), 'blob-origin-group')]"
-                                },
-                                "geoFilters": [],
-                                "deliveryPolicy": {
-                                    "rules": [
-                                        {
-                                            "name": "originOverrideRule",
-                                            "order": 1,
-                                            "conditions": [
-                                                {
-                                                    "name": "UrlPath",
-                                                    "parameters": {
-                                                        "typeName": "DeliveryRuleUrlPathMatchConditionParameters",
-                                                        "operator": "BeginsWith",
-                                                        "negateCondition": true,
-                                                        "matchValues": [
-                                                            "[concat(parameters('stagingBlobContainerName'), '/wp-content/uploads/')]"
-                                                        ],
-                                                        "transforms": [
-                                                            "Lowercase"
-                                                        ]
-                                                    }
-                                                }
-                                            ],
-                                            "actions": [
-                                                {
-                                                    "name": "OriginGroupOverride",
-                                                    "parameters": {
-                                                        "typeName": "DeliveryRuleOriginGroupOverrideActionParameters",
-                                                        "originGroup": {
-                                                            "id": "[resourceId('Microsoft.Cdn/profiles/endpoints/originGroups', parameters('cdnProfileName'), parameters('stagingCdnEndpointName'), 'app-origin-group')]"
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "name": "UrlRewrite",
-                                                    "parameters": {
-                                                        "typeName": "DeliveryRuleUrlRewriteActionParameters",
-                                                        "sourcePattern": "[concat('/', parameters('stagingBlobContainerName'), '/')]",
-                                                        "destination": "/",
-                                                        "preserveUnmatchedPath": true
-                                                    }
-                                                },
-                                                {
-                                                    "name": "ModifyResponseHeader",
-                                                    "parameters": {
-                                                        "typeName": "DeliveryRuleHeaderActionParameters",
-                                                        "headerAction": "Overwrite",
-                                                        "headerName": "Access-Control-Allow-Origin",
-                                                        "value": "https://sample-wordpress-app-staging-g8gbgbgwfvc2fkad.australiacentral-01.azurewebsites.net"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
                             }
                         }
                     ]
@@ -1375,8 +1071,8 @@
                 "[resourceId('Microsoft.DBforMySQL/flexibleServers', parameters('serverName'))]",
                 "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
             ],
-            "resourceGroup": "rajneesh-experiments",
-            "subscriptionId": "9801ce74-29e4-4846-9d02-5010413d1042",
+            "resourceGroup": "[parameters('serverFarmResourceGroup')]",
+            "subscriptionId": "[subscription().subscriptionId]",
             "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -1434,8 +1130,8 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', 'Storage_Resources')]"
             ],
-            "resourceGroup": "rajneesh-experiments",
-            "subscriptionId": "9801ce74-29e4-4846-9d02-5010413d1042",
+            "resourceGroup": "[parameters('serverFarmResourceGroup')]",
+            "subscriptionId": "[subscription().subscriptionId]",
             "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -1467,9 +1163,6 @@
         "databaseVersion": "8.0.21",
         "vnetDeploymentApiVersion": "2020-07-01",
         "privateDnsApiVersion": "2018-09-01",
-        "privateEndpointApiVersion": "2021-03-01",
-        "vnetAddress": "10.0.0.0/23",
-        "cdnApiVersion": "2020-04-15",
         "blobApiVersion": "2021-08-01",
         "storageAccountId": "[resourceId(parameters('storageAccountResourceGroup'),'Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
         "emailApiVersion": "2023-03-31",

--- a/ARM_Template_Create_WP/azuredeploy.json
+++ b/ARM_Template_Create_WP/azuredeploy.json
@@ -210,6 +210,13 @@
             "metadata": {
                 "description": "Set to false to skip subnet creation (useful when subnets already exist)"
             }
+        },
+        "vnetResourceGroup": {
+            "type": "string",
+            "defaultValue": "[parameters('serverFarmResourceGroup')]",
+            "metadata": {
+                "description": "Resource group where the VNet is located. Defaults to serverFarmResourceGroup."
+            }
         }
     },
     "resources": [
@@ -399,7 +406,7 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', parameters('privateDnsZoneNameForDb'), format('{0}-vnetlink', parameters('privateDnsZoneNameForDb')))]",
                 "[concat('Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('managedIdentityName'))]",
-                "[if(parameters('createSubnets'), resourceId('Microsoft.Resources/deployments', 'subnet_Resources'), if(parameters('useExistingVnet'), resourceId('Microsoft.Resources/deployments', 'add_delegations'), resourceId('Microsoft.Network/virtualNetworks/', parameters('vnetName'))))]"
+                "[if(or(not(parameters('useExistingVnet')), parameters('createSubnets')), resourceId('Microsoft.Resources/deployments', 'subnet_Resources'), resourceId('Microsoft.Resources/deployments', 'add_delegations'))]"
             ],
             "identity": {
                 "type": "UserAssigned",
@@ -538,9 +545,12 @@
             "type": "Microsoft.Resources/deployments",
             "name": "subnet_Resources",
             "apiVersion": "[variables('resourceDeploymentApiVersion')]",
-            "condition": "[parameters('createSubnets')]",
+            "condition": "[or(not(parameters('useExistingVnet')), parameters('createSubnets'))]",
             "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
             ],
+            "resourceGroup": "[parameters('vnetResourceGroup')]",
+            "subscriptionId": "[subscription().subscriptionId]",
             "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -595,6 +605,8 @@
             "condition": "[and(parameters('useExistingVnet'), not(parameters('createSubnets')))]",
             "dependsOn": [
             ],
+            "resourceGroup": "[parameters('vnetResourceGroup')]",
+            "subscriptionId": "[subscription().subscriptionId]",
             "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -608,7 +620,7 @@
                             "apiVersion": "2021-03-01",
                             "name": "[format('{0}/{1}', parameters('vnetName'), parameters('subnetForApp'))]",
                             "properties": {
-                                "addressPrefix": "[reference(resourceId(parameters('serverFarmResourceGroup'), 'Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetForApp')), '2021-03-01').addressPrefix]",
+                                "addressPrefix": "[reference(resourceId(parameters('vnetResourceGroup'), 'Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetForApp')), '2021-03-01').addressPrefix]",
                                 "delegations": [
                                     {
                                         "name": "dlg-appService",
@@ -624,7 +636,7 @@
                             "apiVersion": "2021-03-01",
                             "name": "[format('{0}/{1}',parameters('vnetName'), parameters('subnetForDb'))]",
                             "properties": {
-                                "addressPrefix": "[reference(resourceId(parameters('serverFarmResourceGroup'), 'Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetForDb')), '2021-03-01').addressPrefix]",
+                                "addressPrefix": "[reference(resourceId(parameters('vnetResourceGroup'), 'Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetForDb')), '2021-03-01').addressPrefix]",
                                 "delegations": [
                                     {
                                         "name": "dlg-mysql",
@@ -669,7 +681,7 @@
             ],
             "dependsOn": [
                 "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
-                "[if(parameters('createSubnets'), resourceId('Microsoft.Resources/deployments', 'subnet_Resources'), if(parameters('useExistingVnet'), resourceId('Microsoft.Resources/deployments', 'add_delegations'), resourceId('Microsoft.Network/virtualNetworks/', parameters('vnetName'))))]"
+                "[if(or(not(parameters('useExistingVnet')), parameters('createSubnets')), resourceId('Microsoft.Resources/deployments', 'subnet_Resources'), resourceId('Microsoft.Resources/deployments', 'add_delegations'))]"
             ]
         },
         {
@@ -716,7 +728,7 @@
             "properties": {
                 "clientAffinityEnabled": false,
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('hostingPlanName'))]",
-                "virtualNetworkSubnetId": "[concat('/subscriptions/', parameters('subscriptionId'),'/resourcegroups/', parameters('serverFarmResourceGroup'), '/providers/Microsoft.Network/virtualNetworks/', parameters('vnetName'), '/subnets/', parameters('subnetForApp'))]",
+                "virtualNetworkSubnetId": "[concat('/subscriptions/', parameters('subscriptionId'),'/resourcegroups/', parameters('vnetResourceGroup'), '/providers/Microsoft.Network/virtualNetworks/', parameters('vnetName'), '/subnets/', parameters('subnetForApp'))]",
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/ARM_Template_Create_WP/azuredeploy.json
+++ b/ARM_Template_Create_WP/azuredeploy.json
@@ -547,7 +547,7 @@
             "apiVersion": "[variables('resourceDeploymentApiVersion')]",
             "condition": "[or(not(parameters('useExistingVnet')), parameters('createSubnets'))]",
             "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
+                "[if(not(parameters('useExistingVnet')), resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName')), 'dummy')]"
             ],
             "resourceGroup": "[parameters('vnetResourceGroup')]",
             "subscriptionId": "[subscription().subscriptionId]",
@@ -673,14 +673,14 @@
                     ],
                     "properties": {
                         "virtualNetwork": {
-                            "id": "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]"
+                            "id": "[resourceId(parameters('vnetResourceGroup'), 'Microsoft.Network/virtualNetworks/', parameters('vnetName'))]"
                         },
                         "registrationEnabled": false
                     }
                 }
             ],
             "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
+                "[resourceId(parameters('vnetResourceGroup'), 'Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
                 "[if(or(not(parameters('useExistingVnet')), parameters('createSubnets')), resourceId('Microsoft.Resources/deployments', 'subnet_Resources'), resourceId('Microsoft.Resources/deployments', 'add_delegations'))]"
             ]
         },
@@ -689,7 +689,7 @@
             "type": "Microsoft.Web/sites/networkConfig",
             "name": "[format('{0}/{1}', parameters('name'), 'virtualNetwork')]",
             "properties": {
-                "subnetResourceId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetForApp'))]"
+                "subnetResourceId": "[resourceId(parameters('vnetResourceGroup'), 'Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetForApp'))]"
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/Sites', parameters('name'))]",
@@ -1144,8 +1144,8 @@
         "vnetDeploymentApiVersion": "2020-07-01",
         "privateDnsApiVersion": "2018-09-01",
         "vnetAddress": "10.0.0.0/23",
-        "subnetAddressForApp": "10.0.0.0/24",
-        "subnetAddressForDb": "10.0.1.0/24",
+        "subnetAddressForApp": "10.0.0.0/25",
+        "subnetAddressForDb": "10.0.1.0/25",
         "blobApiVersion": "2021-08-01",
         "storageAccountId": "[resourceId(parameters('storageAccountResourceGroup'),'Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
         "emailApiVersion": "2023-03-31",

--- a/ARM_Template_Create_WP/azuredeploy.parameters.json
+++ b/ARM_Template_Create_WP/azuredeploy.parameters.json
@@ -203,11 +203,8 @@
         "createSubnets": {
             "value": true
         },
-        "subnetAddressForApp": {
-            "value": "10.0.0.0/24"
-        },
-        "subnetAddressForDb": {
-            "value": "10.0.1.0/24"
+        "vnetResourceGroup": {
+            "value": null
         }
     }
 }

--- a/ARM_Template_Create_WP/azuredeploy.parameters.json
+++ b/ARM_Template_Create_WP/azuredeploy.parameters.json
@@ -119,18 +119,6 @@
         "wpLocaleCode": {
             "value": "en_US"
         },
-        "cdnProfileName": {
-            "value": "sampleword-39b8672c593dc95a-cdnprofile"
-        },
-        "cdnEndpointName": {
-            "value": "sampleword-39b8672c593dc95a-endpoint"
-        },
-        "cdnType": {
-            "value": "Standard_Microsoft"
-        },
-        "stagingCdnEndpointName": {
-            "value": "sampleword-39b8672c593dc95a-endpoint-staging"
-        },
         "storageAccountName": {
             "value": "sampleword0ab37a5082"
         },
@@ -208,6 +196,24 @@
         },
         "managedIdentityName": {
             "value": "sampleword-49dff026e4-wpidentity"
+        },
+        "useExistingVnet": {
+            "value": false
+        },
+        "createSubnets": {
+            "value": true
+        },
+        "vnetAddressPrefix": {
+            "value": "10.0.0.0/16"
+        },
+        "subnetAddressForApp": {
+            "value": "10.0.0.0/24"
+        },
+        "subnetAddressForDb": {
+            "value": "10.0.1.0/24"
+        },
+        "useExistingPrivateDnsZone": {
+            "value": false
         }
     }
 }

--- a/ARM_Template_Create_WP/azuredeploy.parameters.json
+++ b/ARM_Template_Create_WP/azuredeploy.parameters.json
@@ -203,17 +203,11 @@
         "createSubnets": {
             "value": true
         },
-        "vnetAddressPrefix": {
-            "value": "10.0.0.0/16"
-        },
         "subnetAddressForApp": {
             "value": "10.0.0.0/24"
         },
         "subnetAddressForDb": {
             "value": "10.0.1.0/24"
-        },
-        "useExistingPrivateDnsZone": {
-            "value": false
         }
     }
 }


### PR DESCRIPTION
This PR adds flexible VNet and subnet deployment support with three scenarios:

- New VNet + new subnets - Creates everything from scratch
- Existing VNet + new subnets - Creates subnets in existing VNet
- Existing VNet + existing subnets - Adds delegations to existing subnets without changing address ranges
- 

Changes

- Added parameters: useExistingVnet, createSubnets, vnetAddressPrefix
- Added variables: subnetAddressForApp, subnetAddressForDb
- Added add_delegations deployment that uses reference() to preserve existing subnet address ranges
- Removed CDN references (deprecated)

